### PR TITLE
Add revision parameter

### DIFF
--- a/lib/project-version.model.ts
+++ b/lib/project-version.model.ts
@@ -9,6 +9,11 @@ export interface UnityProjectVersion {
     version: string;
 
     /**
+     * Project version revision, e.g. d691e07d38ef.
+     */
+    revision: string;
+
+    /**
      * Project version identifier with revision, e.g. 2019.3.5f1 (d691e07d38ef).
      */
     versionWithRevision: string;

--- a/lib/project-version.service.ts
+++ b/lib/project-version.service.ts
@@ -27,6 +27,7 @@ export class ProjectVersionService {
 
             return {
                 version: '',
+                revision: '',
                 versionWithRevision: '',
                 isAlpha: false,
                 isBeta: false,
@@ -44,15 +45,24 @@ export class ProjectVersionService {
             const split = content.split(':');
             let projectVersion = split[1].trim();
             let projectVersionWithRevision = '';
+            let revision = '';
 
             const revisionVersionIndex = projectVersion.indexOf('m_EditorVersionWithRevision');
             if (revisionVersionIndex > -1) {
                 projectVersion = projectVersion.substr(0, revisionVersionIndex).trim();
                 projectVersionWithRevision = split[split.length - 1].trim();
+
+                const revisionRegex : RegExp = /.*\((.*)\)/;
+                const revisionRegexResult = revisionRegex.exec(projectVersionWithRevision);
+
+                if (revisionRegexResult != null) {
+                    revision = revisionRegexResult[1];
+                }
             }
 
             return {
                 version: projectVersion,
+                revision: revision,
                 versionWithRevision: projectVersionWithRevision,
                 isAlpha: projectVersion.includes('a'),
                 isBeta: projectVersion.includes('b')
@@ -61,6 +71,7 @@ export class ProjectVersionService {
 
         return {
             version: '',
+            revision: '',
             versionWithRevision: '',
             isAlpha: false,
             isBeta: false,


### PR DESCRIPTION
To be able to install an editor through the Unity Hub CLI you have to pass it a "--changeset" parameter. Example:

"C:\Program Files\Unity Hub\Unity Hub.exe" -- --headless install --version 2020.2.0b8 --changeset dff91d65251a

This PR parses and sets a revision parameter.