### PR TITLE
Undo update of fs-extra package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+### Changed
+
+- Needed to go back to `fs-extra v8.1.0` because the latest version would cause errors with Azure DevOps
+
 ## [1.1.1]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,11 +83,6 @@
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
-        "at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -317,14 +312,13 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-            "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "requires": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^1.0.0"
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -473,19 +467,11 @@
             }
         },
         "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-                }
+                "graceful-fs": "^4.1.6"
             }
         },
         "locate-path": {
@@ -794,9 +780,9 @@
             "dev": true
         },
         "universalify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-            "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dinomite-studios/unity-project-version",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Utility package for determining a project's Unity editor version.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "author": "Dinomite Studios",
     "license": "MIT",
     "dependencies": {
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^8.1.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.14",


### PR DESCRIPTION
Needed to go back with fs-extra to 8.1 because the latest version causes issues with Azure DevOps